### PR TITLE
Fix environment loading in OAuth server

### DIFF
--- a/oauth_server.py
+++ b/oauth_server.py
@@ -3,7 +3,13 @@ import os
 import json
 import time
 import requests
+from dotenv import load_dotenv
 from flask import Flask, request, redirect
+
+# Load environment variables from a .env file if present. This mirrors the
+# behavior of the other modules and ensures CLIENT_ID, CLIENT_SECRET and
+# REDIRECT_URI are populated when running the server locally.
+load_dotenv()
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- load environment variables for OAuth server

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_b_6855e01f8c88832bb5fd784cb5168368